### PR TITLE
Fix registration chain.

### DIFF
--- a/Isengard/app/controllers/registrations_controller.rb
+++ b/Isengard/app/controllers/registrations_controller.rb
@@ -18,7 +18,7 @@ class RegistrationsController < ApplicationController
     authorize! :register, requested_access_level
     @registration = @event.registrations.create params.require(:registration).permit(:email, :name, :student_number)
     @registration.access_levels << requested_access_level
-    @registration.update price: requested_access_level.price
+    @registration.update paid: 0, price: requested_access_level.price
     respond_with @registration
   end
 

--- a/Isengard/app/views/registrations/basic.js.erb
+++ b/Isengard/app/views/registrations/basic.js.erb
@@ -1,1 +1,5 @@
+<% unless @registration.errors.any? %>
+  $('#flash').replaceWith("<%= escape_javascript render partial: 'flash', locals: { flash: { notice: 'Registration succesful' } }  %>")
+  <% @registration = Registration.new %>
+<% end %>
 $('#basic-registration-form').replaceWith('<%= escape_javascript render partial: 'registrations/basic' %>');


### PR DESCRIPTION
On a succesful registration, there will now be a notice with flash, and the form
will be replaced by a new form, so you can chain registrations. On failure, the
same form errors will be shown.

Fix #151.
