### PR TITLE
Rename club to organisation

### DIFF
--- a/Isengard/config/locales/en.yml
+++ b/Isengard/config/locales/en.yml
@@ -24,3 +24,7 @@ en:
       registration:
         access_levels: "Ticket"
 
+  helpers:
+    label:
+      event:
+        club_id: "Organisation"


### PR DESCRIPTION
Some organisations find it offensive to be called a "club" while they are a "kring". I would rename all occurences of club to organisation to avoid this issue.
