### PR TITLE
make the url relative to the page

### DIFF
--- a/Isengard/app/views/welcome/index.html.erb
+++ b/Isengard/app/views/welcome/index.html.erb
@@ -2,4 +2,4 @@
 
 <p>Welcome to Gandalf, an online event management service brought to you by <a href="http://zeus.ugent.be/" target="_blank">Zeus WPI</a> and <a href="http://www.fkgent.be/" target="_blank">FaculteitenKonvent Gent</a></p>
 
-<p>Click on <a href="http://event.fkgent.be/events">Events</a> in the menu to register or buy tickets for an event.</p>
+<p>Click on <a href="/events">Events</a> in the menu to register or buy tickets for an event.</p>


### PR DESCRIPTION
Because it's rather surprising to click on it and suddenly see events in the list you didn't know you had in your database.
