### PR TITLE
Update users after sign_in instead of after_create

### DIFF
--- a/Isengard/app/models/user.rb
+++ b/Isengard/app/models/user.rb
@@ -25,7 +25,7 @@ class User < ActiveRecord::Base
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :cas_authenticatable
 
-  after_create :fetch_club
+  after_initialize :fetch_club
 
   has_and_belongs_to_many :clubs
 


### PR DESCRIPTION
When a change occurs to a user in the Isengard API, this does not get updated in Gandalf.
