### PR TITLE
When a non-bank-csv-thing is uploaded, an error occurs

### DIFF
--- a/Isengard/app/controllers/registrations_controller.rb
+++ b/Isengard/app/controllers/registrations_controller.rb
@@ -138,23 +138,23 @@ class RegistrationsController < ApplicationController
         registration.save
         counter += 1
       end
+
+      flash.now[:success] = "Updated #{ActionController::Base.helpers.pluralize counter, "payment"} successfully."
+      if fails.any?
+        flash.now[:error] = "The rows listed below contained an invalid code, please fix them by hand."
+        @csvheaders = fails.first.headers
+        @csvfails = fails
+        render 'upload'
+      else
+        @registrations = @event.registrations.all.sort_by {:to_pay }.reverse.paginate(page: params[:page], per_page: 15)
+        render 'index'
+      end
     rescue CSV::MalformedCSVError
       flash.now[:error] = "The file could not be parsed. Make sure that you uploaded the correct file and that the column seperator settings have been set to the correct seperator."
       @registrations = @event.registrations.all.sort_by {:to_pay }.reverse.paginate(page: params[:page], per_page: 15)
       render 'index'
-      return
     end
 
-    flash.now[:success] = "Updated #{ActionController::Base.helpers.pluralize counter, "payment"} successfully."
-    if fails.any?
-      flash.now[:error] = "The rows listed below contained an invalid code, please fix them by hand."
-      @csvheaders = fails.first.headers
-      @csvfails = fails
-      render 'upload'
-    else
-      @registrations = @event.registrations.all.sort_by {:to_pay }.reverse.paginate(page: params[:page], per_page: 15)
-      render 'index'
-    end
   end
 
 end


### PR DESCRIPTION
```
CSV::MalformedCSVError in RegistrationsController#upload

    fails = []
    counter = 0
    CSV.parse(params.require(:csv_file).read.upcase, col_sep: sep, headers: :first_row) do |row|
      match = /GAN(?<event_id>\d+)D(?<id>\d+)A(?<sum>\d+)L(?<ssum>\d+)F/.match(row.to_s)
      next unless match # seems like this is not a Gandalf transfer.

app/controllers/registrations_controller.rb:108:in `upload'
```
