### PR TITLE
after_initialize -> after_create

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,9 +25,7 @@ class User < ActiveRecord::Base
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :cas_authenticatable
 
-  if Rails.env.production?
-    after_initialize :fetch_club, :fetch_enrolled_clubs
-  end
+  after_create :fetch_club, :fetch_enrolled_clubs
 
   has_and_belongs_to_many :clubs
   has_and_belongs_to_many :enrolled_clubs, join_table: :enrolled_clubs_members, class_name: "Club"


### PR DESCRIPTION
we will only fetch this once, and then update them when needed.
This will _greatly_ reduce the load and external requests, which are
quite frankly not needed, since this will only update once a year.

I'll use some other library to update them every day during the night.
But this is not a priority atm.
