### PR TITLE
Wrong ticket price for member ticket Filologica - Edit ticket bugged

### DIFF
--- a/app/views/access_levels/_form.html.erb
+++ b/app/views/access_levels/_form.html.erb
@@ -2,7 +2,7 @@
   <%= form_for [object.event, object], remote: true do |f| %>
     <td><%= f.text_field :name, class: 'form-control' %></td>
     <td><%= f.number_field :capacity, class: 'form-control', placeholder: 0 %></td>
-    <td><%= f.text_field :price, class: 'form-control', placeholder: "0.00" %></td>
+    <td><%= f.text_field :price, value: number_with_precision(f.object.price, precision: 2), class: 'form-control', placeholder: "0.00" %></td>
     <td><%= form_check_box f, :public %></td>
     <td><div class="checkbox"><%= f.check_box :has_comment %></div></td>
     <td><div class="checkbox"><%= f.check_box :hidden %></div></td>


### PR DESCRIPTION
For some reason the price of member tickets is multiplied by 100.

![schermopname 52](https://f.cloud.github.com/assets/3730236/2113058/96e91f64-9027-11e3-813e-d55a191ab518.png)
