### PR TITLE
Info button stopped working

### DIFF
--- a/app/views/registrations/_info_content.html.erb
+++ b/app/views/registrations/_info_content.html.erb
@@ -17,7 +17,7 @@
   <% @registration.versions.each do |version| %>
     <tr>
       <td><%= version.event %></td>
-      <td><%= User.find(version.whodunnit).display_name %></td>
+      <td><%= version.whodunnit.nil? ? "Anonymous user" : User.find(version.whodunnit).display_name %></td>
       <td><%= nice_time version.created_at %></td>
       <td>
         <ul class="no-margin no-padding">


### PR DESCRIPTION
`ActiveRecord::RecordNotFound (Couldn't find User without an ID):`

This is because anonymous users can create registrations too, and the info modal requires a user ID.
