### PR TITLE
Add number of paid tickets to each ticket type

### DIFF
--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -23,6 +23,8 @@ class Registration < ActiveRecord::Base
   has_many :accesses, dependent: :destroy
   has_many :access_levels, through: :accesses
 
+  scope :paid, -> { where("price <= paid") }
+
   validates :name, presence: true
   validates :email, presence: true
   validates :student_number, format: {with: /\A[0-9]*\Z/, message: "has invalid format" },

--- a/app/views/access_levels/_access_level.html.erb
+++ b/app/views/access_levels/_access_level.html.erb
@@ -1,7 +1,7 @@
 <tr id="<%= dom_id(access_level) %>">
   <td><%= access_level.name %></td>
   <td>
-    <%= access_level.registrations.count %>/<%= access_level.capacity.presence || "&infin;".html_safe %>
+    <%= access_level.registrations.size %> (<%= access_level.registrations.paid.size %>) / <%= access_level.capacity.presence || "&infin;".html_safe %>
     <span class="label label-<%= color_for_tickets_left(access_level) %> pull-right"><%= "#{pluralize(access_level.tickets_left, "ticket")} left" if access_level.capacity.presence %></span>
   </td>
   <td>&euro; <%= number_with_precision access_level.price || "0", precision: 2  %></td>

--- a/app/views/access_levels/index.html.erb
+++ b/app/views/access_levels/index.html.erb
@@ -7,7 +7,7 @@
       <table class="table" id="table-access-levels">
         <thead>
           <th>Name</th>
-          <th width="150">Sold/Capacity</th>
+          <th width="200">Sold (Paid) /Capacity</th>
           <th>Price</th>
           <th>Availability</th>
           <th>Member Only</th>

--- a/app/views/registrations/index.html.erb
+++ b/app/views/registrations/index.html.erb
@@ -10,8 +10,10 @@
     <span id="export-link">
       <%= render 'events/export' %>
     </span>
-    <%= tag :div, id: "export_status_url", data: {url: export_status_event_path(@event)} %>
+    <%= tag :span, id: "export_status_url", data: {url: export_status_event_path(@event)} %>
+    <span class="pull-right btn btn-default"><strong>Total tickets:</strong> <%= @event.registrations.size %> (<%= @event.registrations.paid.size %> paid)</span>
 
+    <br />
     <br />
 
     <% if @registrations.blank? %>


### PR DESCRIPTION
It would be nice to have something like this in the ticket overview:
X (Y) / Z
where 
X = total number of registrations
Y = total number of paid tickets
Z = total capacity 
