### PR TITLE
Hide private tickets

### DIFF
--- a/app/models/access_level.rb
+++ b/app/models/access_level.rb
@@ -36,6 +36,7 @@ class AccessLevel < ActiveRecord::Base
   end
 
   default_scope { order "price, name" }
+  scope :public, -> { where(public: true) }
 
   def set_zones_by_ids zones
     self.zones = self.event.zones.find zones

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -40,7 +40,7 @@
       <div class="row">
         <div class="col-sm-12">
           <ul class="list-group">
-            <% @event.access_levels.each do |al| %>
+            <% @event.access_levels.public.each do |al| %>
               <%= render partial: "events/ticket", locals: {al: al} %>
             <% end %>
           </ul>


### PR DESCRIPTION
If a ticket is marked private, it should not be displayed in the list of tickets of an event.
