### PR TITLE
Sorting by (un)paid AND access level fails

### DIFF
--- a/app/grids/registrations_grid.rb
+++ b/app/grids/registrations_grid.rb
@@ -10,8 +10,8 @@ class RegistrationsGrid
   filter(:email) { |value| where("lower(registrations.email) like ?", "%#{value.downcase}%") }
   filter(:access_level) { |value, scope| scope.joins(:access_levels).where(access_levels: { id: value }) }
   filter(:payment_code) { |value| where("registrations.payment_code like ?","%#{value}%") }
-  filter(:only_paid) { |value| where("paid = price")  if value == '1' }
-  filter(:only_unpaid) { |value| where.not("paid = price")  if value == '1' }
+  filter(:only_paid) { |value| where("registrations.paid = registrations.price")  if value == '1' }
+  filter(:only_unpaid) { |value| where.not("registrations.paid = registrations.price")  if value == '1' }
 
   column(:name)
   column(:email)


### PR DESCRIPTION
See http://zeus-errbit.ilion.me/apps/530210dc098ef03150000002/problems/55099d0a7a65754f4bca0100

This is because both `registration` and `access_level` have a price column, in `app/grids/registrations_grid.rb`, we should specify which column we select more specifically.