### PR TITLE
Past events should be sorted as most recent first

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -9,11 +9,10 @@ class EventsController < ApplicationController
   respond_to :html, :js, :ics
 
   def index
-    @events = Event.where('end_date > ?', DateTime.now).order(:name)
+    @events = Event.where('end_date > ?', DateTime.now).order(:start_date)
     if user_signed_in?
-      @events += Event.accessible_by(current_ability).to_a
+      @past_events = Event.accessible_by(current_ability).order(:name)
     end
-    @events.uniq!
   end
 
   def show

--- a/app/views/events/_events_table.html.erb
+++ b/app/views/events/_events_table.html.erb
@@ -1,0 +1,13 @@
+<div class="table-responsive">
+  <table class="table table-striped">
+    <thead>
+      <th>Name</th>
+      <th>Organisation</th>
+      <th>Location</th>
+      <th>Start date</th>
+      <th>End date</th>
+      <th width="210">Actions</th>
+    </thead>
+    <%= render events %>
+  </table>
+</div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,18 +1,33 @@
 <div class="row">
   <div class="col-lg-12">
-    <div class="table-responsive">
-      <table class="table table-striped">
-        <thead>
-          <th>Name</th>
-          <th>Organisation</th>
-          <th>Location</th>
-          <th>Start date</th>
-          <th>End date</th>
-          <th width="210">Actions</th>
-        </thead>
-        <%= render @events %>
-      </table>
+
+    <% if can? :crud, Event %>
+    <div role="tabpanel">
+      <!-- Nav tabs -->
+      <ul class="nav nav-tabs" role="tablist">
+        <li role="presentation" class="active"><a href="#upcoming" aria-controls="upcoming" role="tab" data-toggle="tab">Upcoming</a></li>
+        <li role="presentation"><a href="#all" aria-controls="all" role="tab" data-toggle="tab">All</a></li>
+      </ul>
+    <% end %>
+
+    <% if can? :crud, Event %>
+      <!-- Tab panes -->
+      <div class="tab-content">
+        <div role="tabpanel" class="tab-pane active" id="upcoming">
+    <% end %>
+
+          <%= render partial: "events_table", locals: { events: @events } %>
+
+    <% if can? :crud, Event %>
+        </div>
+        <div role="tabpanel" class="tab-pane" id="all">
+          <%= render partial: "events_table", locals: { events: @past_events } %>
+        </div>
+      </div>
+
     </div>
+    <% end %>
+
   </div>
 </div>
 <%= render "events/delete_modal" %>

--- a/test/integration/ticket_manipulation_test.rb
+++ b/test/integration/ticket_manipulation_test.rb
@@ -8,6 +8,7 @@ class TicketManipulationTest < ActionDispatch::IntegrationTest
     sign_in users(:adminfelix)
 
     visit events_path
+    click_on "All"
     click_on events(:codenight).name
     click_on "Tickets"
     fill_in 'access_level_name', with: "Test"


### PR DESCRIPTION
Administrators can see all events, including the ones that are fully closed. It is more logical to sort them  as oldest last. This way you will see the recently closed events first in lieu of the ones that were closed months/years ago.