### PR TITLE
Turbolinks kills wyiwyg editor

### DIFF
--- a/app/views/events/_actions.html.erb
+++ b/app/views/events/_actions.html.erb
@@ -3,6 +3,6 @@
 <% end %>
 
 <% if can? :crud, event %>
-  <%= link_to raw('<span class="glyphicon glyphicon-edit"></span> Edit'), edit_event_path(event), class: "btn btn-default btn-xs" %>
+  <span data-no-turbolink><%= link_to raw('<span class="glyphicon glyphicon-edit"></span> Edit'), edit_event_path(event), class: "btn btn-default btn-xs" %></span>
   <%= link_to raw('<span class="glyphicon glyphicon-trash"></span> Delete'), "#delete-confirm", class: "btn btn-danger btn-xs delete-confirm", :"data-link" => event_path(event) %>
 <% end %>

--- a/app/views/events/_tabs.html.erb
+++ b/app/views/events/_tabs.html.erb
@@ -14,7 +14,7 @@
         <li <%= raw 'class="active"' if current_page?(statistics_event_path(@event)) %>><%= link_to "Statistics", statistics_event_path(@event) %></li>
       <% end %>
       <% if can? :crud, @event %>
-        <li <%= raw 'class="active"' if current_page?(edit_event_path(@event)) %>><%= link_to "Edit event", edit_event_path(@event) %></li>
+        <li <%= raw 'class="active"' if current_page?(edit_event_path(@event)) %> data-no-turbolink><%= link_to "Edit event", edit_event_path(@event) %></li>
         <li <%= raw 'class="active"' if current_page?(event_registrations_path(@event)) %>><%= link_to "Registrations", event_registrations_path(@event) %></li>
         <li <%= raw 'class="active"' if current_page?(event_access_levels_path(@event)) && !@advanced %>><%= link_to "Tickets", event_access_levels_path(@event, advanced: false) %></li>
         <li <%= raw 'class="active"' if current_page?(event_partners_path(@event)) %>><%= link_to "Partners", event_partners_path(@event) %></li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -45,7 +45,7 @@
             <% if can? :crud, Event %>
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">Management <b class="caret"></b></a>
-              <ul class="dropdown-menu">
+              <ul class="dropdown-menu" data-no-turbolink>
                 <li><%= link_to "Create event", new_event_path %></li>
               </ul>
             </li>


### PR DESCRIPTION
When editing an event or trying to mail everyone, you need to refresh the page before the whyiwyg editor appears. As @Silox already found out, this is an issue with turbolinks.