### PR TITLE
Add barcode number as text in mail. 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -131,6 +131,8 @@ gem 'jc-validates_timeliness'
 
 gem 'airbrake'
 
+gem 'rmagick'
+
 # select2 is beautiful
 gem 'select2-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -310,6 +310,7 @@ DEPENDENCIES
   rails (~> 4.0)
   rails-erd
   ri_cal
+  rmagick
   sass-rails (~> 4.0)
   sdoc
   select2-rails

--- a/app/mailers/registration_mailer.rb
+++ b/app/mailers/registration_mailer.rb
@@ -13,7 +13,12 @@ class RegistrationMailer < ActionMailer::Base
     @registration = registration
 
     barcode = Barcodes.create('EAN13', data: registration.barcode_data, bar_width: 35, bar_height: 1500, caption_height: 300, caption_size: 275 ) # required: height > size
-    attachments.inline['barcode.png'] = Barcodes::Renderer::Image.new(barcode).render
+
+    image = Barcodes::Renderer::Image.new(barcode).render
+    attachments.inline['barcode.png'] = image
+
+    tilted_image = Magick::Image.from_blob(image).first.rotate!(-90).to_blob
+    attachments.inline['barcode-tilted.png'] = tilted_image
 
     mail to: "#{registration.name} <#{registration.email}>", subject: "Ticket for #{registration.event.name}"
   end

--- a/app/views/registration_mailer/ticket.html.erb
+++ b/app/views/registration_mailer/ticket.html.erb
@@ -6,15 +6,15 @@
   <body>
     <p>Dear <%= @registration.name %>,</p>
 
-	<p>This email is your ticket to enter the following event:</p>
+  <p>This email is your ticket to enter the following event:</p>
 
-	<table>
-      <tbody>
-	  <tr>
+  <table>
+    <tbody>
+      <tr>
         <td><strong>Event</strong></td>
         <td><%= @registration.event.name %></td>
-	  </tr>
-	  <tr>
+      </tr>
+      <tr>
         <td><strong>Organisation</strong></td>
         <td><%= @registration.event.club.name %></td>
       </tr>
@@ -34,19 +34,22 @@
         <td><strong>Website</strong></td>
         <td><a href="<%= @registration.event.website %>"><%= @registration.event.website %></a></td>
       </tr>
-      </tbody>
-	</table>
+    </tbody>
+  </table>
 
     <p>Below is your personal barcode (ticket type: <%= @registration.access_levels.first.try :name %>).</p>
     <br />
     <%= image_tag attachments['barcode.png'].url %>
-	<br />
+    <%= image_tag attachments['barcode-tilted.png'].url %>
+    <br />
+    Barcode number: <%= @registration.barcode %>
+    <br />
 
     <p><strong>Do not forget to print this email and bring it with you. This email acts as your ticket. Without it, you will not be granted access to <%= @registration.event.name %>.</strong><p>
 
-	<p>If you have any problems, you can contact us via mail: <%= mail_to @registration.event.contact_email, @registration.event.contact_email %></p>
+  <p>If you have any problems, you can contact us via mail: <%= mail_to @registration.event.contact_email, @registration.event.contact_email %></p>
 
-	<p>Kind regards,<br /><%= @registration.event.club.name %></p>
+  <p>Kind regards,<br /><%= @registration.event.club.name %></p>
 
   </body>
 </html>


### PR DESCRIPTION
While observing @thoge at Dies Natalis, I saw that a number of people printed their ticket without a bar code. Their mail clients so not print images. A solution would be to add the barcode number as text to the mail. See the mails from kinepolis as an example. 
![image](https://cloud.githubusercontent.com/assets/1470064/6744149/7a989822-cea5-11e4-9aaa-0e445c71af69.jpg)
