### PR TITLE
Fix the bootstrap event column page

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -5,7 +5,7 @@
     <h3>Description</h3>
     <table class="table word-break">
       <tr>
-        <th>Organisation</th>
+        <th class="col-md-3 col-xs-3">Organisation</th>
         <td><%= @event.club.name %></td>
       </tr>
       <tr>


### PR DESCRIPTION
By settings `table-layout: fixed`, the column width got set equal for both columns, resulting in:

![screen shot 2015-03-24 at 16 45 10](https://cloud.githubusercontent.com/assets/915130/6805781/2606832a-d245-11e4-9b73-d372142157ec.png)


This can be done prewttyweier.