### PR TITLE
No defaults, only suggestions

### DIFF
--- a/app/models/club.rb
+++ b/app/models/club.rb
@@ -25,11 +25,6 @@ class Club < ActiveRecord::Base
   end
 
   def self.ordered_clubs
-    # improve speed
-    ugent = Club.find_by_internal_name 'ugent'
-
-    # ordering like it's 1999
-    clubs = Club.except(ugent).sort_by {|c| c.name}
-    [ugent] + clubs
+    Club.all.sort_by {|c| c.name}
   end
 end

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -60,6 +60,8 @@ class Registration < ActiveRecord::Base
   validates :plus_one_firstname, presence: true, if: 'has_plus_one?'
   validates :plus_one_lastname, presence: true, if: 'has_plus_one?'
 
+  validate :must_select_club
+
   has_paper_trail only: [:paid, :payment_code, :checked_in_at]
 
   before_validation do |record|
@@ -78,6 +80,14 @@ class Registration < ActiveRecord::Base
   end
 
   default_scope { order "lastname ASC" }
+
+  def must_select_club
+    if event&.can_add_club?
+      if club_id.blank? || !Club.exists?(club_id)
+        errors.add(:club_id, :no_club_id)
+      end
+    end
+  end
 
   def paid
     from_cents read_attribute(:paid)

--- a/app/views/registrations/_basic.html.erb
+++ b/app/views/registrations/_basic.html.erb
@@ -35,7 +35,7 @@
     <% end %>
       <% if @registration.event.can_add_club%>
           <p><%= t('event.registration.club.info')%></p>
-        <%= form_collection_select f, :club_id, Club.ordered_clubs, :id, :name %>
+        <%= form_collection_select f, :club_id, Club.ordered_clubs, :id, :name, prompt: t('event.registration.club.prompt') %>
           <%= stylesheet_link_tag  '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/css/select2.min.css' %>
           <%= stylesheet_link_tag  'https://cdnjs.cloudflare.com/ajax/libs/select2-bootstrap-css/1.4.6/select2-bootstrap.min.css' %>
           <%= javascript_include_tag '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/js/select2.min.js' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,6 +20,10 @@ en:
         plus_one_title: Partner title
         register: Register
         title: Title
+    errors:
+      models:
+        registration:
+          no_club_id: ": You have to choose an association to donate €1 to. If you don't have a preference, we suggest 'Zeus WerkgroeP Informatica', the association who made this ticket application possible."
   datagrid:
     table:
       order:
@@ -49,6 +53,7 @@ en:
     registration:
       club:
         info: The foundation ball (Stichtingsbal) is an initiative from the student associations. You donate €1 per ticket to the selected association.
+        prompt: Select an association
     start_date: Start date
     website: Website
   events:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -22,6 +22,10 @@ nl:
         club_id: Vereniging
         payment_method: Betalingswijze
         number_of_tickets: Aantal tickets
+    errors:
+      models:
+        registration:
+          no_club_id: ": Je moet een vereniging opgeven waaraan je €1 schenkt. Heb je geen voorkeur kunnen we je 'Zeus WerkgroeP Informatica' aanbevelen die deze ticketapplicatie mogelijk hebben gemaakt."
   datagrid:
     table:
       order:
@@ -51,7 +55,8 @@ nl:
     website: Website
     registration:
       club:
-        info: Het Stichtingsbal is een initiatief voor en door studentenverenigingen. U schenkt €1 per ticket aan de vereniging die u hieronder selecteert. Heeft u geen vereniging van uw voorkeur kiest u gewoon ‘Universiteit Gent’.
+        info: Het Stichtingsbal is een initiatief voor en door studentenverenigingen. U schenkt €1 per ticket aan de vereniging die u hieronder selecteert.
+        prompt: Selecteer een vereniging
     payments: Betalingen kunnen enkel via bankkaarten gebeuren.
   events:
     club_stats:


### PR DESCRIPTION
Geen voorkeursbehandeling meer maar een vriendelijke suggestie indien de gebruiker geen keuze heeft gemaakt. 

Standaard staat de prompt 'Selecteer een vereniging' geselecteerd. Indien de gebruiker deze optie niet veranderd zal de registratie niet lukken en krijgt de gebruiker de error: 
> Je moet een vereniging opgeven waaraan je €1 schenkt. Heb je geen voorkeur kunnen we je 'Zeus WerkgroeP Informatica' aanbevelen die deze ticketapplicatie mogelijk hebben gemaakt.

Zo moet de gebruiker bewust kiezen aan wie de euro wordt geschonken.