### PR TITLE
Fix/535/allow selecting current organisation when editing event

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -153,7 +153,7 @@ class EventsController < ApplicationController
   end
 
   def event_params
-    params.require(:event).permit(:name, :club_id, :location, :website, :contact_email, :start_date, :end_date, :description, :bank_number, :registration_close_date, :registration_open_date, :show_ticket_count, :signature)
+    params.require(:event).permit(:name, :location, :website, :contact_email, :start_date, :end_date, :description, :bank_number, :registration_close_date, :registration_open_date, :show_ticket_count, :signature)
   end
 
   def event_create_params

--- a/app/views/events/_general_form.html.erb
+++ b/app/views/events/_general_form.html.erb
@@ -2,7 +2,6 @@
   <%= form_for @event do |f| %>
 
     <%= form_text_field f, :name %>
-    <%= form_collection_select f, :club_id, current_user.clubs, :id, :name %>
     <%= form_text_field f, :location %>
     <%= form_url_field f, :website %>
     <%= form_email_field f, :contact_email %>


### PR DESCRIPTION
Relies on https://github.com/ZeusWPI/Gandalf/pull/571
Fixes https://github.com/ZeusWPI/Gandalf/pull/573

We're not going to allow changing the club of an event when editing the event, that's a bit silly and can lead to all sorts of issues.