### PR TITLE
Add ticket overview screen

### DIFF
--- a/app/actions/generate_html_barcodes.rb
+++ b/app/actions/generate_html_barcodes.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'barby/barcode/ean_13'
+require 'barby/outputter/html_outputter'
+
+class GenerateHtmlBarcodes
+  def initialize(barcode_data)
+    @barcode_data = barcode_data
+  end
+
+  def call
+    barcode = Barby::EAN13.new(@barcode_data)
+
+    html_outputter = Barby::HtmlOutputter.new(barcode)
+    html_outputter.to_html.html_safe # rubocop:disable Rails/OutputSafety
+  end
+end

--- a/app/assets/stylesheets/barcodes.css.scss
+++ b/app/assets/stylesheets/barcodes.css.scss
@@ -1,0 +1,4 @@
+table.barby-barcode { border-spacing: 0; }
+tr.barby-row {}
+td.barby-cell { width: 3px; height: 70px; }
+td.barby-cell.on { background: #000; }

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -20,6 +20,14 @@ class RegistrationsController < ApplicationController
     @registrations = @registrations.paginate(page: params[:page], per_page: 25)
   end
 
+  def show
+    @registration = Registration.find_by(token: params[:token])
+    return head(:not_found) unless @registration
+
+    @event = @registration.event
+    @barcode = GenerateHtmlBarcodes.new(@registration.barcode_data).call
+  end
+
   def new
     @event = Event.find params.require(:event_id)
     @registration = Registration.new
@@ -52,14 +60,6 @@ class RegistrationsController < ApplicationController
     else
       render "events/show"
     end
-  end
-
-  def show
-    @registration = Registration.find_by(token: params[:token])
-    return head(:not_found) unless @registration
-
-    @event = @registration.event
-    @barcode = GenerateHtmlBarcodes.new(@registration.barcode_data).call
   end
 
   def update

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class RegistrationsController < ApplicationController
-  before_action :authenticate_user!, only: [:index, :destroy, :resend, :update, :email, :upload]
+  before_action :authenticate_user!, except: [:new, :create, :show]
 
   require 'csv'
 
@@ -47,10 +47,19 @@ class RegistrationsController < ApplicationController
       @registration.deliver
 
       flash[:success] = "Registration successful. Please check your mailbox for your ticket or further payment information."
-      respond_with @event
+
+      redirect_to event_registration_path(@registration.event, @registration.token)
     else
       render "events/show"
     end
+  end
+
+  def show
+    @registration = Registration.find_by(token: params[:token])
+    return head(:not_found) unless @registration
+
+    @event = @registration.event
+    @barcode = GenerateHtmlBarcodes.new(@registration.barcode_data).call
   end
 
   def update

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,8 +10,12 @@ module ApplicationHelper
     field.try { |d| d.strftime("%Y-%m-%d %H:%M") }
   end
 
+  def nice_amount(float)
+    number_with_precision float, precision: 2
+  end
+
   def euro(float)
-    "&euro;#{number_with_precision float, precision: 2}"
+    number_to_currency(float, unit: '€')
   end
 
   # Form helpers

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -26,6 +26,8 @@ class Registration < ApplicationRecord
     record.payment_code = Registration.create_payment_code if record.payment_code.nil?
   end
 
+  before_save :ensure_token
+
   after_save do |record|
     if !record.access_level.capacity.nil? && (record.access_level.registrations.count > record.access_level.capacity)
       record.errors.add :access_level, "type is sold out."
@@ -95,6 +97,10 @@ class Registration < ApplicationRecord
     end
   end
 
+  def ensure_token
+    self.token ||= SecureRandom.uuid
+  end
+
   private
 
   def from_cents(value)
@@ -122,6 +128,7 @@ end
 #  payment_code    :string(255)
 #  price           :integer
 #  student_number  :string(255)
+#  token           :string(255)      not null
 #  created_at      :datetime
 #  updated_at      :datetime
 #  access_level_id :integer          not null
@@ -132,6 +139,7 @@ end
 #  index_registrations_on_access_level_id  (access_level_id)
 #  index_registrations_on_event_id         (event_id)
 #  index_registrations_on_payment_code     (payment_code) UNIQUE
+#  index_registrations_on_token            (token)
 #
 # Foreign Keys
 #

--- a/app/views/access_levels/_access_level.html.erb
+++ b/app/views/access_levels/_access_level.html.erb
@@ -4,7 +4,7 @@
     <%= access_level.registrations.size %> (<%= access_level.registrations.paid.size %>) / <%= access_level.capacity.presence || "&infin;".html_safe %>
     <span class="label label-<%= color_for_tickets_left(access_level) %> pull-right"><%= "#{pluralize(access_level.tickets_left, "ticket")} left" if access_level.capacity.presence %></span>
   </td>
-  <td>&euro; <%= number_with_precision access_level.price || "0", precision: 2  %></td>
+  <td>€<%= nice_amount(access_level.price || "0") %></td>
   <td><%= translate access_level.permit %></td>
   <td><%= access_level.has_comment ? 'Yes' : 'No' %></td>
   <td><%= access_level.hidden ? 'Yes' : 'No' %></td>

--- a/app/views/access_levels/_form.html.erb
+++ b/app/views/access_levels/_form.html.erb
@@ -2,7 +2,7 @@
   <%= form_for [object.event, object], remote: true do |f| %>
     <td><%= f.text_field :name, class: 'form-control' %></td>
     <td><%= f.number_field :capacity, class: 'form-control', placeholder: 0 %></td>
-    <td><%= f.text_field :price, value: number_with_precision(f.object.price, precision: 2), class: 'form-control', placeholder: "0.00" %></td>
+    <td><%= f.text_field :price, value: nice_amount(f.object.price), class: 'form-control', placeholder: "0.00" %></td>
     <td width="130px">
       <%= f.collection_select :permit, AccessLevel.permits.keys, :itself, lambda {|k| translate(k)}, {}, class: 'form-control' %>
     </td>

--- a/app/views/events/_event_details.html.erb
+++ b/app/views/events/_event_details.html.erb
@@ -1,0 +1,45 @@
+<h3>Description</h3>
+<table class="table word-break">
+  <tr>
+    <th class="col-md-3 col-xs-3">Organisation</th>
+    <td><%= event.club.name %></td>
+  </tr>
+  <tr>
+    <th>Location</th>
+    <td><%= event.location %></td>
+  </tr>
+  <tr>
+    <th>Start date</th>
+    <td><%= nice_time event.start_date %></td>
+  </tr>
+  <tr>
+    <th>End date</th>
+    <td><%= nice_time event.end_date %></td>
+  </tr>
+  <tr>
+    <td colspan="2">
+      <%= event.description.html_safe %>
+    </td>
+  </tr>
+  <tr>
+    <th>Website</th>
+    <td><%= link_to event.website, event.website %></td>
+  </tr>
+  <tr>
+    <th>Contact e-mail</th>
+    <td><%= mail_to event.contact_email, event.contact_email %></td>
+  </tr>
+</table>
+
+<% unless event.access_levels.blank? %>
+  <h3>Tickets</h3>
+  <div class="row">
+    <div class="col-sm-12">
+      <ul class="list-group">
+        <% event.access_levels.public?.each do |al| %>
+          <%= render partial: "events/ticket", locals: {al: al} %>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+<% end %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -2,51 +2,7 @@
 
 <div class="row">
   <div class="col-sm-7">
-    <h3>Description</h3>
-    <table class="table word-break">
-      <tr>
-        <th class="col-md-3 col-xs-3">Organisation</th>
-        <td><%= @event.club.name %></td>
-      </tr>
-      <tr>
-        <th>Location</th>
-        <td><%= @event.location %></td>
-      </tr>
-      <tr>
-        <th>Start date</th>
-        <td><%= nice_time @event.start_date %></td>
-      </tr>
-      <tr>
-        <th>End date</th>
-        <td><%= nice_time @event.end_date %></td>
-      </tr>
-      <tr>
-        <td colspan="2">
-           <%= @event.description.html_safe %>
-        </td>
-      </tr>
-      <tr>
-        <th>Website</th>
-        <td><%= link_to @event.website, @event.website %></td>
-      </tr>
-      <tr>
-        <th>Contact e-mail</th>
-        <td><%= mail_to @event.contact_email, @event.contact_email %></td>
-      </tr>
-    </table>
-
-    <% unless @event.access_levels.blank? %>
-      <h3>Tickets</h3>
-      <div class="row">
-        <div class="col-sm-12">
-          <ul class="list-group">
-            <% @event.access_levels.public?.each do |al| %>
-              <%= render partial: "events/ticket", locals: {al: al} %>
-            <% end %>
-          </ul>
-        </div>
-      </div>
-    <% end %>
+    <%= render partial: 'events/event_details', locals: { event: @event } %>
   </div>
 
   <div class="col-sm-4 col-sm-offset-1">

--- a/app/views/registration_mailer/confirm_registration.html.erb
+++ b/app/views/registration_mailer/confirm_registration.html.erb
@@ -13,6 +13,8 @@
 
 	<p><strong>Gelieve ten laatste 3 dagen voor het evenement te betalen.</strong> Indien dit niet meer lukt, gelieve ons te contacteren via <%= mail_to @registration.event.contact_email, @registration.event.contact_email %> om een andere betalingswijze af te spreken. Eens we uw betaling verwerkt hebben, zal u uw ticket via e-mail ontvangen.</p>
 
+        <p>U kan deze informatie ook altijd herbekijken op <a href="<%= event_registration_url(@registration.event, @registration.token) %>">deze pagina</a>.
+
 	<p>Mocht er zich eender welk probleem voordoen, kan u ons altijd via e-mail contacteren: <%= mail_to @registration.event.contact_email, @registration.event.contact_email %></p>
 
 	<p>Met vriendelijke groet,<br /><%= @registration.event.club.name %></p>
@@ -30,6 +32,8 @@
 	<p>To receive your ticket by mail, please transfer <%= nice_amount @registration.to_pay %> euro to <%= @registration.event.bank_number || "our bank account" %>. Place "<%= @registration.payment_code %>" in the description of your transfer (without the quotation marks). If you forget this code or you do not copy it correctly, we cannot process your payment and you will not receive your ticket. You are only allowed to enter one code per transfer.</p>
 
 	<p><strong>Please pay at least 3 days before the event.</strong> If this is no longer possible, please contact us via <%= mail_to @registration.event.contact_email, @registration.event.contact_email %> to agree upon a different payment method. You will receive your ticket by mail once we processed your payment.</p>
+
+        <p>You can always view this information on <a href="<%= event_registration_url(@registration.event, @registration.token) %>">this page</a>.
 
 	<p>If you have any problems, you can contact us via mail: <%= mail_to @registration.event.contact_email, @registration.event.contact_email %></p>
 

--- a/app/views/registration_mailer/confirm_registration.html.erb
+++ b/app/views/registration_mailer/confirm_registration.html.erb
@@ -9,7 +9,7 @@
 
 	<p>Bedankt voor het bestellen van een ticket voor <%= @registration.event.name %> van <%= @registration.event.club.name %>. Als u zich niet opgegeven hebt voor dit ticket, dan heeft iemand anders uw e-mailadres gebruikt om dit te registreren. Mocht dit het geval zijn, mag u deze e-mail negeren.</p>
 
-	<p>Om uw ticket te ontvangen via e-mail, schrijft u <%= number_with_precision @registration.to_pay, precision: 2 %> euro over op het rekeningnummer <%= @registration.event.bank_number || "our bank account" %>. Plaats de code "<%= @registration.payment_code %>" in de mededeling van de overschrijving (zonder aanhalingstekens). Als u de code vergeet mee te geven of niet correct vermeldt in de beschrijving, dan kunnen wij uw betaling niet verwerken en zal u uw ticket niet ontvangen. U mag maximaal één code ingeven per overschrijving.</p>
+	<p>Om uw ticket te ontvangen via e-mail, schrijft u <%= nice_amount @registration.to_pay %> euro over op het rekeningnummer <%= @registration.event.bank_number || "our bank account" %>. Plaats de code "<%= @registration.payment_code %>" in de mededeling van de overschrijving (zonder aanhalingstekens). Als u de code vergeet mee te geven of niet correct vermeldt in de beschrijving, dan kunnen wij uw betaling niet verwerken en zal u uw ticket niet ontvangen. U mag maximaal één code ingeven per overschrijving.</p>
 
 	<p><strong>Gelieve ten laatste 3 dagen voor het evenement te betalen.</strong> Indien dit niet meer lukt, gelieve ons te contacteren via <%= mail_to @registration.event.contact_email, @registration.event.contact_email %> om een andere betalingswijze af te spreken. Eens we uw betaling verwerkt hebben, zal u uw ticket via e-mail ontvangen.</p>
 
@@ -27,7 +27,7 @@
 
 	<p>Thank you for buying a ticket for <%= @registration.event.name %> of <%= @registration.event.club.name %>. If you did not register for this ticket, someone else used your email address to register. If this is the case, please ignore this email.</p>
 
-	<p>To receive your ticket by mail, please transfer <%= number_with_precision @registration.to_pay, precision: 2 %> euro to <%= @registration.event.bank_number || "our bank account" %>. Place "<%= @registration.payment_code %>" in the description of your transfer (without the quotation marks). If you forget this code or you do not copy it correctly, we cannot process your payment and you will not receive your ticket. You are only allowed to enter one code per transfer.</p>
+	<p>To receive your ticket by mail, please transfer <%= nice_amount @registration.to_pay %> euro to <%= @registration.event.bank_number || "our bank account" %>. Place "<%= @registration.payment_code %>" in the description of your transfer (without the quotation marks). If you forget this code or you do not copy it correctly, we cannot process your payment and you will not receive your ticket. You are only allowed to enter one code per transfer.</p>
 
 	<p><strong>Please pay at least 3 days before the event.</strong> If this is no longer possible, please contact us via <%= mail_to @registration.event.contact_email, @registration.event.contact_email %> to agree upon a different payment method. You will receive your ticket by mail once we processed your payment.</p>
 

--- a/app/views/registration_mailer/confirm_registration.text.erb
+++ b/app/views/registration_mailer/confirm_registration.text.erb
@@ -4,7 +4,7 @@ Beste <%= @registration.name %>,
 
 Bedankt voor het bestellen van een ticket voor <%= @registration.event.name %> van <%= @registration.event.club.name %>. Als u zich niet opgegeven hebt voor dit ticket, dan heeft iemand anders uw e-mailadres gebruikt om dit te registreren. Mocht dit het geval zijn, mag u deze e-mail negeren.
 
-Om uw ticket te ontvangen via e-mail, schrijft u <%= number_with_precision @registration.to_pay, precision: 2 %> euro over op het rekeningnummer <%= @registration.event.bank_number || "our bank account" %>. Plaats de code "<%= @registration.payment_code %>" in de mededeling van de overschrijving (zonder aanhalingstekens). Als u de code vergeet mee te geven of niet correct vermeldt in de beschrijving, dan kunnen wij uw betaling niet verwerken en zal u uw ticket niet ontvangen. U mag maximaal 1 code ingeven per overschrijving.
+Om uw ticket te ontvangen via e-mail, schrijft u <%= nice_amount @registration.to_pay %> euro over op het rekeningnummer <%= @registration.event.bank_number || "our bank account" %>. Plaats de code "<%= @registration.payment_code %>" in de mededeling van de overschrijving (zonder aanhalingstekens). Als u de code vergeet mee te geven of niet correct vermeldt in de beschrijving, dan kunnen wij uw betaling niet verwerken en zal u uw ticket niet ontvangen. U mag maximaal 1 code ingeven per overschrijving.
 
 Gelieve ten laatste 3 dagen voor het evenement te betalen. Indien dit niet meer lukt, gelieve ons te contacteren via <%= @registration.event.contact_email %> om een andere betalingswijze af te spreken. Eens we uw betaling verwerkt hebben, zal u uw ticket via e-mail ontvangen.
 
@@ -23,7 +23,7 @@ Dear <%= @registration.name %>,
 
 Thank you for buying a ticket for <%= @registration.event.name %> of <%= @registration.event.club.name %>. If you did not register for this ticket, someone else used your email address to register. If this is the case, please ignore this email.
 
-To receive your ticket by mail, please transfer <%= number_with_precision @registration.to_pay, precision: 2 %> euro to <%= @registration.event.bank_number || "our bank account" %>. Place "<%= @registration.payment_code %>" in the description of your transfer (without the quotation marks). If you forget this code or you do not copy it correctly, we cannot process your payment and you will not receive your ticket. You are only allowed to enter one code per transfer.
+To receive your ticket by mail, please transfer <%= nice_amount @registration.to_pay %> euro to <%= @registration.event.bank_number || "our bank account" %>. Place "<%= @registration.payment_code %>" in the description of your transfer (without the quotation marks). If you forget this code or you do not copy it correctly, we cannot process your payment and you will not receive your ticket. You are only allowed to enter one code per transfer.
 
 Please pay at least 3 days before the event. If this is no longer possible, please contact us via <%= @registration.event.contact_email %> to agree upon a different payment method. You will receive your ticket by mail once we processed your payment.
 

--- a/app/views/registrations/_registration_payment_form.html.erb
+++ b/app/views/registrations/_registration_payment_form.html.erb
@@ -1,8 +1,8 @@
 <%= form_for [registration.event, registration], method: :patch, remote: true, html: { class: 'form-inline' } do |f| %>
   <div class="input-group input-group-sm <%= f.object.paid? ? 'has-success' : 'has-error' %>">
-      <div class="input-group-addon">&euro;</div>
-      <%= f.text_field :to_pay, value: number_with_precision(f.object.to_pay, precision: 2), disabled: true, class: 'disabling registration-paid form-control' %>
-      <%= f.hidden_field :price, value: number_with_precision(f.object.price, precision: 2), disabled: true, class: 'registration-price' %>
+      <div class="input-group-addon">€</div>
+      <%= f.text_field :to_pay, value: nice_amount(f.object.to_pay), disabled: true, class: 'disabling registration-paid form-control' %>
+      <%= f.hidden_field :price, value: nice_amount(f.object.price), disabled: true, class: 'registration-price' %>
       <div class="input-group-addon">
         <%= check_box_tag 'is_paid', '1', f.object.paid?, class: 'disabling registration-box input-append', disabled: true %>
       </div>

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -1,0 +1,62 @@
+<div class="row">
+  <div class="col-sm-6">
+    <%= render partial: 'events/event_details', locals: { event: @event } %>
+    <p>
+      <%= link_to "Register another ticket", event_path(@registration.event) %>
+    </p>
+  </div>
+
+  <div class="col-sm-5 col-sm-offset-1">
+    <h3>Your ticket</h3>
+    <table class="table word-break">
+      <tr>
+        <th class="col-md-3 col-xs-3">Name</th>
+        <td><%= @registration.name %></td>
+      </tr>
+      <tr>
+        <th class="col-md-3 col-xs-3">Email</th>
+        <td><%= @registration.email %></td>
+      </tr>
+      <tr>
+        <th class="col-md-3 col-xs-3">Ticket</th>
+        <td><%= @registration.access_level.name %></td>
+      </tr>
+    </table>
+
+    <% if @registration.paid? %>
+      <div>
+        <%= @barcode %>
+      </div>
+      <div style="transform: rotate(-90deg); transform-origin: top left; margin-top: 300px;">
+        <div>
+          <%= @barcode %>
+        </div>
+      </div>
+    <% else %>
+      <h3>Payment</h3>
+      <table class="table word-break">
+        <tr>
+          <th class="col-md-3 col-xs-3">Price</th>
+          <td><%= euro @registration.access_level.price %></td>
+        </tr>
+        <tr>
+          <th class="col-md-3 col-xs-3">Already paid</th>
+          <td>- <%= euro @registration.paid %></td>
+        </tr>
+        <tr>
+          <th class="col-md-3 col-xs-3">Remaining</th>
+          <td><%= euro @registration.to_pay %></td>
+        </tr>
+      </table>
+
+      <p>
+        Om uw ticket te ontvangen via e-mail, schrijft u <strong><%= nice_amount @registration.to_pay %> euro</strong>
+        over op het rekeningnummer <strong><%= @registration.event.bank_number || "our bank account" %></strong>. Plaats de code
+        <strong>"<%= @registration.payment_code %>"</strong> in de mededeling van de overschrijving (zonder aanhalingstekens). <br />
+        Als u de
+        code vergeet mee te geven of niet correct vermeldt in de beschrijving, dan kunnen wij uw betaling niet verwerken
+        en zal u uw ticket niet ontvangen. U mag maximaal één code ingeven per overschrijving.
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,7 +36,7 @@ Rails.application.configure do
   config.action_mailer.perform_deliveries = true
 
   # Set base URL because emails don't have the Host header context
-  config.action_mailer.default_url_options = { :host => 'https://localhost:3000' }
+  config.action_mailer.default_url_options = { :host => 'http://localhost:3000' }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -35,6 +35,9 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  # Set base URL because emails don't have the Host header context
+  config.action_mailer.default_url_options = { :host => 'http://example.com' }
+
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,7 +38,8 @@ Isengard::Application.routes.draw do
       end
     end
     resources :role_names
-    resources :registrations do
+
+    resources :registrations, except: [:show] do
       member do
         get 'resend'
         get 'info'
@@ -49,6 +50,7 @@ Isengard::Application.routes.draw do
         post 'email'
       end
     end
+    resources :registrations, only: [:show], param: :token
 
     member do
       get 'statistics'

--- a/db/migrate/20221009173017_add_token_to_registration.rb
+++ b/db/migrate/20221009173017_add_token_to_registration.rb
@@ -1,0 +1,17 @@
+class AddTokenToRegistration < ActiveRecord::Migration[6.1]
+  def up
+    # To be converted to UUID type when there's support for it in Rails+MySQL
+    add_column :registrations, :token, :string, null: true
+    Registration.find_each do |r|
+      r.update_column(:token, SecureRandom.uuid)
+    end
+    change_column_null :registrations, :token, false
+
+    add_index :registrations, :token
+  end
+
+  def down
+    remove_index :registrations, :token
+    remove_column :registrations, :token
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_09_134241) do
+ActiveRecord::Schema.define(version: 2022_10_09_173017) do
 
   create_table "access_levels", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name"
@@ -142,9 +142,11 @@ ActiveRecord::Schema.define(version: 2022_10_09_134241) do
     t.string "barcode_data"
     t.string "payment_code"
     t.integer "access_level_id", null: false
+    t.string "token", null: false
     t.index ["access_level_id"], name: "index_registrations_on_access_level_id"
     t.index ["event_id"], name: "index_registrations_on_event_id"
     t.index ["payment_code"], name: "index_registrations_on_payment_code", unique: true
+    t.index ["token"], name: "index_registrations_on_token"
   end
 
   create_table "users", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/test/fixtures/registrations.yml
+++ b/test/fixtures/registrations.yml
@@ -12,6 +12,7 @@ one:
   price: 0
   payment_code: <%= Registration.create_payment_code %>
   access_level_id: 1
+  token: <%= SecureRandom.uuid %>
 
 two:
   id: 2
@@ -25,6 +26,7 @@ two:
   price: 10
   payment_code: <%= Registration.create_payment_code %>
   access_level_id: 2
+  token: <%= SecureRandom.uuid %>
 
 three:
   id: 3
@@ -38,6 +40,7 @@ three:
   price: 20
   payment_code: GAN7539840256920891
   access_level_id: 1
+  token: <%= SecureRandom.uuid %>
 
 four:
   id: 4
@@ -51,6 +54,7 @@ four:
   price: 10
   payment_code: <%= Registration.create_payment_code %>
   access_level_id: 1
+  token: <%= SecureRandom.uuid %>
 
 <% 9.times do |n| %>
 capacity_registration_<%= n %>:
@@ -64,6 +68,7 @@ capacity_registration_<%= n %>:
   student_number: <%= 100 + n %>
   payment_code: <%= Registration.create_payment_code %>
   access_level_id: <%= 100 + (n % 3) %>
+  token: <%= SecureRandom.uuid %>
 <% end %>
 
 # == Schema Information
@@ -81,6 +86,7 @@ capacity_registration_<%= n %>:
 #  payment_code    :string(255)
 #  price           :integer
 #  student_number  :string(255)
+#  token           :string(255)      not null
 #  created_at      :datetime
 #  updated_at      :datetime
 #  access_level_id :integer          not null
@@ -91,6 +97,7 @@ capacity_registration_<%= n %>:
 #  index_registrations_on_access_level_id  (access_level_id)
 #  index_registrations_on_event_id         (event_id)
 #  index_registrations_on_payment_code     (payment_code) UNIQUE
+#  index_registrations_on_token            (token)
 #
 # Foreign Keys
 #

--- a/test/models/registration_test.rb
+++ b/test/models/registration_test.rb
@@ -79,6 +79,7 @@ end
 #  payment_code    :string(255)
 #  price           :integer
 #  student_number  :string(255)
+#  token           :string(255)      not null
 #  created_at      :datetime
 #  updated_at      :datetime
 #  access_level_id :integer          not null
@@ -89,6 +90,7 @@ end
 #  index_registrations_on_access_level_id  (access_level_id)
 #  index_registrations_on_event_id         (event_id)
 #  index_registrations_on_payment_code     (payment_code) UNIQUE
+#  index_registrations_on_token            (token)
 #
 # Foreign Keys
 #


### PR DESCRIPTION
Start of an overview screen where users will be able to:
- see their information (both event, ticket, barcode and payment information)
- change details (will be handled in another issue)
- cancel (will be handled in another issue)

Todo:
- [x] add a link to this overview in the email

![Screenshot 2022-10-15 at 21 47 37](https://user-images.githubusercontent.com/915130/196005156-eaf32735-5896-406d-b1cd-3c5734a3892c.png)


![Screenshot 2022-10-15 at 21 48 26](https://user-images.githubusercontent.com/915130/196005185-b79b6690-794c-4675-a0f8-8d17379fcbc1.png)
