### PR TITLE
Add Nix flake for devshell

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 In short, Gandalf is a project that does everything that makes organising and managing an event a lot easier for FK-clubs of the University of Ghent. The application is written specifically for the UGent FakulteitenKonvent. It allows students to register for events and it also interacts with the FK-Enrolment database and allows members of student unions to subscribe to member-only events from their clubs.
 
 # Getting started
+
+If you have NixOS or Nix installed, you can use the `flake.nix` to avoid the hassle of installing the right dependencies. Scroll down for more info.
+
 0. Install the prerequisites: ruby 3.0.6, preferably using [asdf](https://asdf-vm.com/), and some system libraries depending on your OS (e.g. imagemagick)
 1. Install the ruby dependencies: `bin/bundle`
 2. Start up the database, sidekiq and rails server by running `bin/dev`
@@ -13,6 +16,14 @@ In short, Gandalf is a project that does everything that makes organising and ma
 4. Browse to http://localhost:3000
 
 In case you want to start the webserver in your IDE, just run `docker-compose up -d` and start Sidekiq manually (`bundle exec sidekiq`)
+
+## Development using Nix
+
+- Make sure you have [Nix](https://nixos.org/download.html#download-nix) installed.
+- Run `nix develop`
+- Done! You have everything installed. You can now:
+    1. Install Ruby dependencies with `gems:refresh`
+    2. Start EVERYTHING with `server:start`
 
 # Manually adding users to clubs / making users admin
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,85 @@
+{
+  "nodes": {
+    "devshell": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1678798690,
+        "narHash": "sha256-ES6PnlxlQ8ROzHhMKUzuvwmTZvoift1LXyG+LN7TBNI=",
+        "owner": "chvp",
+        "repo": "devshell",
+        "rev": "5f31e3757888be373af78b724982bb4018406c98",
+        "type": "github"
+      },
+      "original": {
+        "owner": "chvp",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1681737997,
+        "narHash": "sha256-pHhjgsIkRMu80LmVe8QoKIZB6VZGRRxFmIvsC5S89k4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "f00994e78cd39e6fc966f0c4103f908e63284780",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devshell": "devshell",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,96 @@
+{
+  description = "Gandalf";
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    devshell = {
+      url = "github:chvp/devshell";
+      inputs = {
+        flake-utils.follows = "flake-utils";
+        nixpkgs.follows = "nixpkgs";
+      };
+    };
+  };
+
+  outputs = { self, nixpkgs, devshell, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; overlays = [ devshell.overlays.default ]; };
+      in
+      {
+        devShells = rec {
+          default = gandalf;
+          gandalf = pkgs.devshell.mkShell {
+            name = "Gandalf";
+            imports = [ "${devshell}/extra/language/ruby.nix" ];
+            packages = with pkgs; [
+              docker
+              nodejs
+              libyaml
+              imagemagick
+            ];
+            language.ruby = {
+              package = pkgs.ruby_3_0;
+              nativeDeps = [ pkgs.libmysqlclient pkgs.zlib ];
+            };
+            env = [
+              {
+                name = "DATABASE_ROOT_PASSWORD";
+                eval = "gandalf";
+              }
+              {
+                name = "TEST_DATABASE_URL";
+                eval = "mysql2://root:gandalf@127.0.0.1:3306/gandalf_test";
+              }
+              {
+                name = "DATABASE_URL";
+                eval = "mysql2://root:gandalf@127.0.0.1:3306/gandalf";
+              }
+            ];
+            serviceGroups.server.services = {
+              rails = {
+                name = "server";
+                command = "rails db:prepare && rails s -p 3000";
+              };
+              mysql.command = "mysql";
+              redis.command = "redis-server --port 6379";
+              sidekiq.command = "bundle exec sidekiq";
+            };
+            commands = [
+              {
+                name = "gems:refresh";
+                category = "general commands";
+                help = "Install dependencies";
+                command = ''
+                  bundle install
+                  bundle pristine
+                '';
+              }
+              {
+                name = "mysql";
+                category = "database";
+                help = "Start database docker";
+                command = ''
+                  trap "systemd-run --user docker stop gandalf-db" 0
+                  docker run --name gandalf-db -p 3306:3306 --rm -v gandalf-db-data:/var/lib/mysql -e MYSQL_ROOT_PASSWORD=$DATABASE_ROOT_PASSWORD mariadb:latest &
+                  wait
+                '';
+              }
+              {
+                name = "mysql-console";
+                category = "database";
+                help = "Open database console";
+                command = ''
+                  docker exec -i gandalf-db mysql -uroot -p"$DATABASE_ROOT_PASSWORD"
+                '';
+              }
+              {
+                name = "redis";
+                package = pkgs.redis;
+              }
+            ];
+          };
+        };
+      }
+    );
+}


### PR DESCRIPTION
This adds a `flake.nix` with a [devshell](https://github.com/numtide/devshell) which enables easy development setup using Nix.

I've updated the README to mention this as an alternative development setup.