### PR TITLE
Use html editor to write emails

### DIFF
--- a/app/views/registrations/_email_modal.html.erb
+++ b/app/views/registrations/_email_modal.html.erb
@@ -12,10 +12,13 @@
               <%= select_tag "to", options_for_select([["All", -1]] + @event.access_levels.map{|a| [a.name, a.id]}), {class: 'form-control'} %>
             </div>
             <div class="form-group">
+              <label class="control-label">Subject:</label>
                <input type="text" class="form-control" name="email[subject]" id="emailSubject" placeholder="Subject">
             </div>
             <div class="form-group">
-              <textarea rows="5" class="form-control" name="email[body]" id="emailBody" placeholder="HTML body"></textarea>
+              <label class="control-label">Email body:</label>
+              <textarea rows="5" class="form-control tinymce" name="email[body]" id="emailBody" placeholder="Email body"></textarea>
+              <%= tinymce %>
             </div>
         </div>
         <div class="modal-footer">


### PR DESCRIPTION
@TomNaessens I didn't use the `form_fancy_text_area` helper but used it's contents. I couldn't get the helper to work.

### Old UI email:
<img src="https://user-images.githubusercontent.com/47608311/233217310-89d1266d-f167-40c0-9ac4-edf3aea8ee5a.png" width="300" />

### Old UI rendered email:
<img src="https://user-images.githubusercontent.com/47608311/233217583-aa382a0e-fbf9-4f12-b8d7-80b456a45362.png" width="300" />


### New UI:
<img src="https://user-images.githubusercontent.com/47608311/233216856-58425c9d-308e-45f9-a216-551cd6ab8e30.png" width="300" />

### New UI email (textarea stretched bigger to show full email):
<img src="https://user-images.githubusercontent.com/47608311/233216338-1fbd9689-a090-4a02-8491-c9090dc071d4.png" width="300" />

### New UI rendered email:
![23-04-20_00:46:35](https://user-images.githubusercontent.com/47608311/233216684-d158ee62-1dff-4472-b072-41643ad4957c.png)
